### PR TITLE
Moved some links to Tools section, added more articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,123 @@
 # Resources
 
-Welcome to the [DeveloperDAO](https://github.com/Developer-DAO/developer-dao) **Knowledge Base**.  
+Welcome to the [DeveloperDAO](https://github.com/Developer-DAO/developer-dao) **Knowledge Base**.
 
 The community has created this knowledge base to help you **learn** and **grow** in your Web3 journey, whether you want to start learning about Web3, or you're building your first dApp, or you're deep into the world of solidity.
 
 ## Terminology
+
 - Visit the [Glossary](GLOSSARY.md) to understand more about a specific term.
 
 ## Getting Started with Web3 Development
 
-### 💡  Learning about Web3
+### 💡 Learning about Web3
+
 - [What is Web3? The Decentralized Internet of the Future Explained](https://www.freecodecamp.org/news/what-is-web3/)
 - [How to Break into Ethereum, Crypto, and Web3 as a Developer](https://www.freecodecamp.org/news/breaking-into-ethereum-crypto-web3-as-a-developer/)
 
-### 📄  Tutorials
+### 📄 Tutorials
+
 - [The Complete Guide to Full Stack Ethereum Development](https://dev.to/dabit3/the-complete-guide-to-full-stack-ethereum-development-3j13)
 
-    This guide by [Nader Dabit](https://github.com/dabit3) is especially useful for Web2 devs and provides a basic understanding of building a full stack dApp from end-to-end using technologies including Hardhat, Solidity, Ethers.js, The Graph, and React.
+  This guide by [Nader Dabit](https://github.com/dabit3) is especially useful for Web2 devs and provides a basic understanding of building a full stack dApp from end-to-end using technologies including Hardhat, Solidity, Ethers.js, The Graph, and React.
 
-- [Scaffold-ETH](https://github.com/scaffold-eth/scaffold-eth)
+- [How to write your first decentralized app - scaffold-eth Challenge 1: Staking dApp](https://dev.to/stermi/scaffold-eth-challenge-1-staking-dapp-4ofb)
 
-    Scaffold-ETH by [Austin Griffith](https://github.com/austintgriffith) provides a full stack development environment for you to quickly learn and experiment with Solidity. Scaffold-ETH includes examples, challenges, and more to help you understand how to implement smart contracts in various scenarios.
+  This guide by [Emanuele Ricci](https://twitter.com/StErMi) will cover in depth the first speed run challenge from scaffold-eth. Inside you will find web3/solidity concepts, explanations and detailed code review.
 
-### 📺  Content Creator Channels
+- [How to create an ERC20 Token and a Solidity Vendor Contract to sell/buy your own token](https://dev.to/stermi/how-to-create-an-erc20-token-and-a-solidity-vendor-contract-to-sell-buy-your-own-token-4j1m)
+
+  This guide by [Emanuele Ricci](https://twitter.com/StErMi) will cover in depth the second speed run challenge from scaffold-eth. Inside you will find web3/solidity concepts, explanations and detailed code review.
+
+- [How to deploy your first smart contract on Ethereum with Solidity and Hardhat](https://dev.to/stermi/how-to-deploy-your-first-smart-contract-on-ethereum-with-solidity-and-hardhat-5efc)
+
+  This guide by [Emanuele Ricci](https://twitter.com/StErMi) will cover how to configure Hardhat to compile, deploy test and debug a Solidity project. You will learn to create a smart contract, test it with Waffle, deploy it on Rinkeby and get it verified by Etherscan.
+
+### 📺 Content Creator Channels
+
 - [Nader Dabit on YouTube](https://www.youtube.com/c/naderdabit)
 - [Austin Griffith on YouTube](https://www.youtube.com/c/naderdabit)
 - [Patrick Collins on YouTube](https://www.youtube.com/channel/UCn-3f8tw_E1jZvhuHatROwA)
 - [Whiteboard Crypto on YouTube](https://www.youtube.com/channel/UCsYYksPHiGqXHPoHI-fm5sg)
 
 ### 📚 Docs
+
 - [Ethereum Development Documentation](https://ethereum.org/en/developers/docs/)
 - [Solidity Documentation](https://docs.soliditylang.org/en/v0.8.8/index.html)
 - [Solidity By Example](https://docs.soliditylang.org/en/v0.8.8/solidity-by-example.html)
 
-### 🎮  Interactive Game Tutorials
+### 🎮 Interactive Game Tutorials
+
 - [CryptoZombies](https://cryptozombies.io/en/solidity)
 - [Capture the Ether](https://capturetheether.com/)
 
 ### 🔨 Tools
+
 - [Remix IDE](https://remix.ethereum.org/)
 - [ETH.Build](https://eth.build/)
 - [Etherscan](https://etherscan.io/)
+- [scaffold-eth](https://github.com/scaffold-eth/scaffold-eth) - 🏗 forkable Ethereum dev stack focused on fast product iterations
+- [eth-hooks](https://github.com/scaffold-eth/eth-hooks) - Commonly used Ethereum hooks to create a web3 application
+- [eth-components](https://github.com/scaffold-eth/eth-components) - React library of commonly used Ethereum components to kickstart your next web3 react app
 
 ## Technologies
 
 ### Ethereum
+
 - [Ethereum Development Documentation](https://ethereum.org/en/developers/docs/)
 - [Hardhat Documentation](https://hardhat.org/getting-started/)
 - [Solidity Documentation](https://docs.soliditylang.org/en/v0.8.8/index.html)
 - [Truffle Suite Documentation](https://www.trufflesuite.com/docs)
 
 ### Solana
+
 - [Solana Developer Resources](https://github.com/CristinaSolana/solana-developer-resources)
 
 ## Use Cases
 
 ### DeFi
+
 - Examples:
-   - [UniSwap](https://uniswap.org/)
+  - [UniSwap](https://uniswap.org/)
 
 ### NFT Marketplaces
+
 - Examples:
-   - [OpenSea](https://opensea.io/)
+  - [OpenSea](https://opensea.io/)
 - Tutorials:
-   - [Building a Full Stack NFT Marketplace on Ethereum with Polygon](https://dev.to/dabit3/building-scalable-full-stack-apps-on-ethereum-with-polygon-2cfb)
+  - [Building a Full Stack NFT Marketplace on Ethereum with Polygon](https://dev.to/dabit3/building-scalable-full-stack-apps-on-ethereum-with-polygon-2cfb)
 
 ### Games
+
 - Examples:
-   - [CryptoKitties](https://www.cryptokitties.co/)
-   - [LootWars](https://lootwars.xyz/)
+  - [CryptoKitties](https://www.cryptokitties.co/)
+  - [LootWars](https://lootwars.xyz/)
 
 ## Courses
 
 ### Free Courses
-- [Buildspace](https://www.buildspace.so) 
 
-    Action-oriented and community-driven course platform. Learn how to build a simple dApp or mint your own NFTs in just hours. (More courses later)
+- [Buildspace](https://www.buildspace.so)
+
+  Action-oriented and community-driven course platform. Learn how to build a simple dApp or mint your own NFTs in just hours. (More courses later)
 
 - [Solidity by Example](https://solidity-by-example.org/)
 
-    Summary and examples of most common Solidity functions, use-cases, real smart contracts, and more. 
+  Summary and examples of most common Solidity functions, use-cases, real smart contracts, and more.
 
 ### Paid Courses
+
 - [Ethereum and Solidity: The Complete Developer's Guide](https://www.udemy.com/course/ethereum-and-solidity-the-complete-developers-guide/) (Udemy)
 - [Smart Contracts con Solidity de la A a la Z](https://www.udemy.com/course/solidity-a-z/learn/lecture/26791510?start=0#overview) (Udemy) (Spanish)
 
 ## Other helpful resources
+
 - [OpenZeppelin](https://openzeppelin.com/contracts/)
 
-    Security standards and tools to build safe smart contracts on Solidity. Free for anyone to use. 
+  Security standards and tools to build safe smart contracts on Solidity. Free for anyone to use.
 
 ## Contributing
 
-Thanks for showing interest in contributing to DeveloperDAO's Resources page. 
+Thanks for showing interest in contributing to DeveloperDAO's Resources page.
 
 Before submitting any changes please review our contributing gudielines in [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Hi there,

I've moved `scaffold-eth` related content to `tools` (because they are dev tools) and added a couple of articles I've made. Let me know if that's ok or what I need to change.