### PR TITLE
Fix buildspace url

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The community has created this knowledge base to help you **learn** and **grow**
 ## Courses
 
 ### Free Courses
-- [Buildspace](https://www.buildspace.so) 
+- [Buildspace](https://buildspace.so) 
 
     Action-oriented and community-driven course platform. Learn how to build a simple dApp or mint your own NFTs in just hours. (More courses later)
 


### PR DESCRIPTION
Removed the `www.` as the subdomain doesn't seem to be setup.